### PR TITLE
Allow to see the error line highlighted

### DIFF
--- a/sourceview.py
+++ b/sourceview.py
@@ -69,8 +69,9 @@ class SourceView(QsciScintilla):
         self.setText(open(filename).read())
 
     def jumpToLine(self, line_number):
-
         self.setCursorPosition(line_number-1,0)
+        # prevent issues with initially invisible cursor / caret line
+        self.setFocus()
         self.standardCommands().find(QsciCommand.VerticalCentreCaret).execute()
 
     #def resizeEvent(self, event):
@@ -79,8 +80,6 @@ class SourceView(QsciScintilla):
 
     def showEvent(self, event):
         QsciScintilla.showEvent(self, event)
-        # prevent issues with initially invisible cursor / caret line
-        self.setFocus()
         #self.jumpToLine(0)
         # prevent issues with incorrect initial scroll position
         self.standardCommands().find(QsciCommand.VerticalCentreCaret).execute()


### PR DESCRIPTION
...while interacting with the traceback list in the debug widget.

I really like to see error messages in the Debug widget, but the error line is not highlighted unless the sourceview gets the focus.

I here propose you to always set the focus to the sourceview once one selects a traceback list item. This has a downside, though. It disables up/down arrows interaction with the traceback list. 

![highlight](https://user-images.githubusercontent.com/652785/66101622-2ec35b80-e575-11e9-91d4-3f902d3c0348.gif)
