### PR TITLE
Add "debug" as tag

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -15,6 +15,7 @@ about=Provides Python debugger and replaces the default Python error handling in
   with a more sophisticated handler that allows more thorough inspection
   or the Python error: browse the frames, view variables, see source code
   or even execute Python code within the context of the error.
+tags=debug
 
 changelog=2.1.2 - Bug fixes:
   - fix startup warnings


### PR DESCRIPTION
I wrote a few times "debug" in the plugin manager to install this plugin. But the list was always empty ;-)