### PR TITLE
Change debugging tools shortcut to Ctrl+F12

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -88,8 +88,8 @@ class FirstAidPlugin(object):
         deferred_dw_handler = DeferredExceptionObject(qgis.utils.iface.mainWindow())
 
         icon = QIcon(os.path.join(os.path.dirname(__file__), "icons", "bug.svg"))
-        self.action_debugger = QAction(icon, "Debug (F12)", qgis.utils.iface.mainWindow())
-        self.action_debugger.setShortcut("F12")
+        self.action_debugger = QAction(icon, "Debug (Ctrl + F12)", qgis.utils.iface.mainWindow())
+        self.action_debugger.setShortcut("Ctrl+F12")
         self.action_debugger.triggered.connect(self.run_debugger)
         qgis.utils.iface.addToolBarIcon(self.action_debugger)
 


### PR DESCRIPTION
F12 clashes with the widely used network logger plugin, and also the unified debugging tools shortcut proposed by https://github.com/qgis/QGIS/pull/35319