### PR TITLE
Minor fixes

### DIFF
--- a/debuggerwidget.py
+++ b/debuggerwidget.py
@@ -222,7 +222,7 @@ class SourceWidget(QPlainTextEdit):
         while block.isValid() and top <= event.rect().bottom():
             if block.isVisible() and bottom >= event.rect().top():
                 painter.setPen(Qt.black)
-                painter.drawText(0, top, self.lineNumberArea.width() - self.fontMetrics().width('9'),
+                painter.drawText(0, int(top), self.lineNumberArea.width() - self.fontMetrics().width('9'),
                                  self.fontMetrics().height(), Qt.AlignRight, str(blockNumber + 1))
             block = block.next()
             top = bottom

--- a/debuggerwidget.py
+++ b/debuggerwidget.py
@@ -159,7 +159,8 @@ class SourceWidget(QPlainTextEdit):
     def __init__(self, filename, parent=None):
         QTextEdit.__init__(self, parent)
 
-        file_content = open(filename).read()
+        with open(filename, "r", encoding="utf-8") as f:
+            file_content = f.read()
         self.setPlainText(file_content)
 
         # this should use the default mono spaced font as set in the system


### PR DESCRIPTION
A couple of minor fixes:

- use context manager when loading file in the debugger to avoid `ResourceWarning: unclosed file` warning
- explicitly cast `top` position to int when drawing line numbers. Without this cast on some systems you get `TypeError: arguments did not match any overloaded call` because `top` variable contains float value