### PR TITLE
Fix line not highlighted upon debug window startup

### DIFF
--- a/debugwidget.py
+++ b/debugwidget.py
@@ -388,9 +388,10 @@ class DebugWidget(QWidget):
     def go_to_frame(self, index):
 
         filename = self.entries[index][0]
-        self.source.line = self.entries[index][1]
+        lineno = self.entries[index][1]
 
         self.source.openFile(filename)
+        self.source.jumpToLine(lineno)
 
         local_vars = frame_from_traceback(self.tb, index).f_locals
         self.variables.setVariables(local_vars)

--- a/debugwidget.py
+++ b/debugwidget.py
@@ -388,10 +388,9 @@ class DebugWidget(QWidget):
     def go_to_frame(self, index):
 
         filename = self.entries[index][0]
-        lineno = self.entries[index][1]
+        self.source.line = self.entries[index][1]
 
         self.source.openFile(filename)
-        self.source.jumpToLine(lineno)
 
         local_vars = frame_from_traceback(self.tb, index).f_locals
         self.variables.setVariables(local_vars)

--- a/sourceview.py
+++ b/sourceview.py
@@ -54,7 +54,6 @@ class SourceView(QgsCodeEditorPython):
 
     def showEvent(self, event):
         QsciScintilla.showEvent(self, event)
-        self.jumpToLine(self.line)
         # self.jumpToLine(0)
         # prevent issues with incorrect initial scroll position
         self.standardCommands().find(QsciCommand.Command.VerticalCentreCaret).execute()

--- a/sourceview.py
+++ b/sourceview.py
@@ -34,7 +34,6 @@ class SourceView(QgsCodeEditorPython):
 
     def __init__(self, parent=None):
         QgsCodeEditorPython.__init__(self, parent)
-        self.line: int = 0
 
         # make the source read-only
         self.SendScintilla(QsciScintilla.SCI_SETREADONLY, True)

--- a/sourceview.py
+++ b/sourceview.py
@@ -55,6 +55,7 @@ class SourceView(QgsCodeEditorPython):
 
     def showEvent(self, event):
         QsciScintilla.showEvent(self, event)
+        self.jumpToLine(self.line)
         # self.jumpToLine(0)
         # prevent issues with incorrect initial scroll position
         self.standardCommands().find(QsciCommand.Command.VerticalCentreCaret).execute()

--- a/sourceview.py
+++ b/sourceview.py
@@ -54,6 +54,7 @@ class SourceView(QgsCodeEditorPython):
 
     def showEvent(self, event):
         QsciScintilla.showEvent(self, event)
+        self.setFocus()
         # self.jumpToLine(0)
         # prevent issues with incorrect initial scroll position
         self.standardCommands().find(QsciCommand.Command.VerticalCentreCaret).execute()

--- a/sourceview.py
+++ b/sourceview.py
@@ -34,6 +34,7 @@ class SourceView(QgsCodeEditorPython):
 
     def __init__(self, parent=None):
         QgsCodeEditorPython.__init__(self, parent)
+        self.line: int = 0
 
         # make the source read-only
         self.SendScintilla(QsciScintilla.SCI_SETREADONLY, True)


### PR DESCRIPTION
An alternative would be to uncomment `# self.jumpToLine(0)` in `showEvent()`, is there a reason for this being commented out?