### PR TITLE
Add warning symbol at problem line

### DIFF
--- a/firstaid/debugwidget.py
+++ b/firstaid/debugwidget.py
@@ -382,11 +382,13 @@ class DebugWidget(QWidget):
             self.go_to_frame(row)
 
     def go_to_frame(self, index):
+        self.source.clearWarnings()
         filename = self.entries[index][0]
         lineno = self.entries[index][1]
 
         self.source.openFile(filename)
         self.source.jumpToLine(lineno)
+        self.source.addWarning(lineno-1, self.etype.__name__)
 
         local_vars = frame_from_traceback(self.tb, index).f_locals
         self.variables.setVariables(local_vars)

--- a/firstaid/debugwidget.py
+++ b/firstaid/debugwidget.py
@@ -388,7 +388,7 @@ class DebugWidget(QWidget):
 
         self.source.openFile(filename)
         self.source.jumpToLine(lineno)
-        self.source.addWarning(lineno-1, self.etype.__name__)
+        self.source.addWarning(lineno - 1, self.etype.__name__)
 
         local_vars = frame_from_traceback(self.tb, index).f_locals
         self.variables.setVariables(local_vars)

--- a/test_script.py
+++ b/test_script.py
@@ -4,14 +4,14 @@
 def fact(n):
     res = n
     if n > 1:
-        res *= fact(n-1)
+        res *= fact(n - 1)
     return res
 
 
 def quicksort(lst):
     if len(lst) < 2:
         return lst
-    pivot_index = len(lst)/2
+    pivot_index = len(lst) / 2
     pivot = lst[pivot_index]
     lower = [x for x in lst if x < pivot]
     higher = [x for x in lst if x > pivot]


### PR DESCRIPTION
Print the type of error alongside it. Not the full error, as it might be a bit confusing since it dosen't show the line in the original script? E.g. for a script with one line `import geopandas` it shows  `mod = _builtin_import(name, globals, locals, fromlist, level)` in utils.py.