### PR TITLE
Use QgsCodeEditorWidget when available 

### DIFF
--- a/firstaid/debugwidget.py
+++ b/firstaid/debugwidget.py
@@ -392,13 +392,21 @@ class DebugWidget(QWidget):
             self.go_to_frame(row)
 
     def go_to_frame(self, index):
-        self.source.clearWarnings()
+        if self._source_editor_widget:
+            self._source_editor_widget.clearWarnings()
+        else:
+            self.source.clearWarnings()
+
         filename = self.entries[index][0]
         lineno = self.entries[index][1]
 
         self.source.openFile(filename)
         self.source.jumpToLine(lineno)
-        self.source.addWarning(lineno - 1, self.etype.__name__)
+        if self._source_editor_widget:
+            self._source_editor_widget.addWarning(
+                lineno - 1, self.etype.__name__)
+        else:
+            self.source.addWarning(lineno - 1, self.etype.__name__)
 
         local_vars = frame_from_traceback(self.tb, index).f_locals
         self.variables.setVariables(local_vars)

--- a/firstaid/debugwidget.py
+++ b/firstaid/debugwidget.py
@@ -36,6 +36,11 @@ from qgis.PyQt.QtGui import QGuiApplication, QIcon, QFontMetrics
 from qgis.core import Qgis, QgsApplication
 from qgis.gui import QgsGui, QgsCodeEditorPython
 
+try:
+    from qgis.gui import QgsCodeEditorWidget
+except ImportError:
+    QgsCodeEditorWidget = None
+
 from .variablesview import VariablesView
 from .sourceview import SourceView
 from .framesview import FramesView
@@ -328,7 +333,12 @@ class DebugWidget(QWidget):
 
         self.splitterSrc = QSplitter(Qt.Orientation.Horizontal)
         self.splitterSrc.addWidget(self.frames)
-        self.splitterSrc.addWidget(self.source)
+        if QgsCodeEditorWidget is not None:
+            self._source_editor_widget = QgsCodeEditorWidget(self.source)
+            self.splitterSrc.addWidget(self._source_editor_widget)
+        else:
+            self._source_editor_widget = None
+            self.splitterSrc.addWidget(self.source)
         self.splitterSrc.setStretchFactor(0, 1)
         self.splitterSrc.setStretchFactor(1, 2)
         self.splitterSrc.setCollapsible(0, False)

--- a/firstaid/debugwidget.py
+++ b/firstaid/debugwidget.py
@@ -403,8 +403,7 @@ class DebugWidget(QWidget):
         self.source.openFile(filename)
         self.source.jumpToLine(lineno)
         if self._source_editor_widget:
-            self._source_editor_widget.addWarning(
-                lineno - 1, self.etype.__name__)
+            self._source_editor_widget.addWarning(lineno - 1, self.etype.__name__)
         else:
             self.source.addWarning(lineno - 1, self.etype.__name__)
 


### PR DESCRIPTION
Only works in 3.37+ QGIS builds, but gives us extra functionality in the code browser window such as Ctrl+F to find text and red highlights at the error locations in the scrollbars

(Blocked by https://github.com/qgis/QGIS/pull/57429)